### PR TITLE
feat: add language toggle and Spanish translations

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,8 @@
 import React from "react"
 import { BrowserRouter as Router } from "react-router-dom"
 import { DEFAULT_POSE } from "./templates"
-import { SECTION_NAMES } from "./components/vars"
 import { Nav, NavDetailed, DimensionsWidget } from "./components"
+import translations from "./translations"
 import { updateHexapod, Page } from "./AppHelpers"
 import HexapodPlot from "./components/HexapodPlot"
 
@@ -16,19 +16,25 @@ class App extends React.Component {
         inHexapodPage: false,
         hexapod: updateHexapod("default"),
         revision: 0,
+        language: "es",
     }
 
     /* * * * * * * * * * * * * *
      * Page load Callback
      * * * * * * * * * * * * * */
 
-    onPageLoad = pageName => {
-        document.title = pageName + " - Mithi's Bare Minimum Hexapod Robot Simulator"
+    toggleLanguage = () =>
+        this.setState({ language: this.state.language === "es" ? "en" : "es" })
+
+    onPageLoad = pageKey => {
+        const pageName = translations[this.state.language].sections[pageKey]
+        document.title =
+            pageName + " - Mithi's Bare Minimum Hexapod Robot Simulator"
         gtag("config", "UA-170794768-1", {
             page_path: window.location.pathname + window.location.search,
         })
 
-        if (pageName === SECTION_NAMES.landingPage) {
+        if (pageKey === "landingPage") {
             this.setState({ inHexapodPage: false })
             return
         }
@@ -57,6 +63,7 @@ class App extends React.Component {
         <Component
             onMount={this.onPageLoad}
             onUpdate={this.manageState}
+            language={this.state.language}
             params={{
                 dimensions: this.state.hexapod.dimensions,
                 pose: this.state.hexapod.pose,
@@ -70,17 +77,23 @@ class App extends React.Component {
 
     render = () => (
         <Router>
-            <Nav />
+            <Nav
+                language={this.state.language}
+                toggleLanguage={this.toggleLanguage}
+            />
             <div id="main">
                 <div id="sidebar">
                     <div hidden={!this.state.inHexapodPage}>
                         <DimensionsWidget
                             params={{ dimensions: this.state.hexapod.dimensions }}
                             onUpdate={this.manageState}
+                            language={this.state.language}
                         />
                     </div>
                     <Page pageComponent={this.pageComponent} />
-                    {!this.state.inHexapodPage ? <NavDetailed /> : null}
+                    {!this.state.inHexapodPage ? (
+                        <NavDetailed language={this.state.language} />
+                    ) : null}
                 </div>
                 <div id="plot" className="border" hidden={!this.state.inHexapodPage}>
                     <HexapodPlot
@@ -89,7 +102,9 @@ class App extends React.Component {
                     />
                 </div>
             </div>
-            {this.state.inHexapodPage ? <NavDetailed /> : null}
+            {this.state.inHexapodPage ? (
+                <NavDetailed language={this.state.language} />
+            ) : null}
         </Router>
     )
 }

--- a/src/AppHelpers.js
+++ b/src/AppHelpers.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { Route, Switch, Redirect } from "react-router-dom"
-import { PATHS } from "./components/vars"
+import { PATH_NAMES } from "./components/vars"
 import * as defaults from "./templates"
 import { VirtualHexapod } from "./hexapod"
 import {
@@ -16,16 +16,16 @@ const Page = ({ pageComponent }) => (
         <Route path="/" exact>
             {pageComponent(LandingPage)}
         </Route>
-        <Route path={PATHS.legPatterns.path} exact>
+        <Route path={PATH_NAMES.legPatterns} exact>
             {pageComponent(LegPatternPage)}
         </Route>
-        <Route path={PATHS.forwardKinematics.path} exact>
+        <Route path={PATH_NAMES.forwardKinematics} exact>
             {pageComponent(ForwardKinematicsPage)}
         </Route>
-        <Route path={PATHS.inverseKinematics.path} exact>
+        <Route path={PATH_NAMES.inverseKinematics} exact>
             {pageComponent(InverseKinematicsPage)}
         </Route>
-        <Route path={PATHS.walkingGaits.path} exact>
+        <Route path={PATH_NAMES.walkingGaits} exact>
             {pageComponent(WalkingGaitsPage)}
         </Route>
         <Route>

--- a/src/components/DimensionsWidget.js
+++ b/src/components/DimensionsWidget.js
@@ -2,10 +2,11 @@ import React, { Component } from "react"
 import NumberInputField from "./generic/NumberInputField"
 import { Card, ResetButton, ToggleSwitch } from "./generic/SmallWidgets"
 import { DEFAULT_DIMENSIONS } from "../templates"
-import { SECTION_NAMES, DIMENSION_NAMES, RANGE_PARAMS } from "./vars"
+import { DIMENSION_NAMES, RANGE_PARAMS } from "./vars"
+import translations from "../translations"
 
 class DimensionsWidget extends Component {
-    sectionName = SECTION_NAMES.dimensions
+    sectionKey = "dimensions"
     state = { isFine: true }
 
     reset = () => this.props.onUpdate("dimensions", { dimensions: DEFAULT_DIMENSIONS })
@@ -49,12 +50,16 @@ class DimensionsWidget extends Component {
         return <div className="grid-cols-6">{numberInputFields}</div>
     }
 
-    render = () => (
-        <Card title={<h2>{this.sectionName}</h2>} other={this.toggleSwitch}>
-            {this.NumberInputFields}
-            <ResetButton reset={this.reset} />
-        </Card>
-    )
+    render = () => {
+        const { language = "es" } = this.props
+        const sectionName = translations[language].sections[this.sectionKey]
+        return (
+            <Card title={<h2>{sectionName}</h2>} other={this.toggleSwitch}>
+                {this.NumberInputFields}
+                <ResetButton reset={this.reset} language={language} />
+            </Card>
+        )
+    }
 }
 
 export default DimensionsWidget

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -1,9 +1,57 @@
 import React from "react"
-import { URL_LINKS, PATH_LINKS } from "./vars"
 import { Link } from "react-router-dom"
+import { PATH_NAMES, ICON_COMPONENTS } from "./vars"
+import translations from "../translations"
+import { FaLanguage } from "react-icons/fa"
 
 const NAV_BULLETS_PREFIX = "navBullet"
 const NAV_DETAILED_PREFIX = "navDetailed"
+
+const buildLinks = language => {
+    const t = translations[language]
+    const PATH_LINKS = [
+        {
+            path: PATH_NAMES.inverseKinematics,
+            description: t.sections.inverseKinematics,
+            icon: ICON_COMPONENTS.circle,
+        },
+        {
+            path: PATH_NAMES.forwardKinematics,
+            description: t.sections.forwardKinematics,
+            icon: ICON_COMPONENTS.circle,
+        },
+        {
+            path: PATH_NAMES.legPatterns,
+            description: t.sections.legPatterns,
+            icon: ICON_COMPONENTS.circle,
+        },
+        {
+            path: PATH_NAMES.walkingGaits,
+            description: t.sections.walkingGaits,
+            icon: ICON_COMPONENTS.circle,
+        },
+        {
+            path: PATH_NAMES.landingPage,
+            description: t.sections.landingPage,
+            icon: ICON_COMPONENTS.home,
+        },
+    ]
+
+    const URL_LINKS = [
+        {
+            url: "https://ko-fi.com/minimithi",
+            icon: ICON_COMPONENTS.mug,
+            description: t.nav.kofi,
+        },
+        {
+            url: "https://github.com/mithi/hexapod",
+            icon: ICON_COMPONENTS.octocat,
+            description: t.nav.repo,
+        },
+    ]
+
+    return { PATH_LINKS, URL_LINKS }
+}
 
 const BulletPageLink = ({ link, showDesc }) => (
     <li>
@@ -31,47 +79,68 @@ const BulletUrlLink = ({ path, description, icon }) => (
     </li>
 )
 
-const NavBullets = () => (
-    <ul id="top-bar">
-        {URL_LINKS.map(link => (
-            <BulletUrlLink
-                path={link.url}
-                key={NAV_BULLETS_PREFIX + link.url}
-                icon={link.icon}
-            />
-        ))}
+const NavBullets = ({ language, toggleLanguage }) => {
+    const { PATH_LINKS, URL_LINKS } = buildLinks(language)
+    return (
+        <ul id="top-bar">
+            {URL_LINKS.map(link => (
+                <BulletUrlLink
+                    path={link.url}
+                    key={NAV_BULLETS_PREFIX + link.url}
+                    icon={link.icon}
+                />
+            ))}
 
-        {PATH_LINKS.map(link => (
-            <BulletPageLink key={NAV_BULLETS_PREFIX + link.path} link={link} />
-        ))}
-    </ul>
+            {PATH_LINKS.map(link => (
+                <BulletPageLink key={NAV_BULLETS_PREFIX + link.path} link={link} />
+            ))}
+
+            <li>
+                <button
+                    onClick={toggleLanguage}
+                    className="link-icon"
+                    aria-label="toggle language"
+                >
+                    <span>
+                        <FaLanguage className="vertical-align" />
+                        {language === "es" ? " EN" : " ES"}
+                    </span>
+                </button>
+            </li>
+        </ul>
+    )
+}
+
+const NavDetailed = ({ language }) => {
+    const { PATH_LINKS, URL_LINKS } = buildLinks(language)
+    return (
+        <footer>
+            <nav id="nav">
+                <ul className="grid-cols-1 no-bullet">
+                    {URL_LINKS.map(link => (
+                        <BulletUrlLink
+                            path={link.url}
+                            key={NAV_DETAILED_PREFIX + link.url}
+                            icon={link.icon}
+                            description={link.description}
+                        />
+                    ))}
+
+                    {PATH_LINKS.map(link => (
+                        <BulletPageLink
+                            key={NAV_DETAILED_PREFIX + link.path}
+                            link={link}
+                            showDesc={true}
+                        />
+                    ))}
+                </ul>
+            </nav>
+        </footer>
+    )
+}
+
+const Nav = ({ language, toggleLanguage }) => (
+    <NavBullets language={language} toggleLanguage={toggleLanguage} />
 )
-
-const NavDetailed = () => (
-    <footer>
-        <nav id="nav">
-            <ul className="grid-cols-1 no-bullet">
-                {URL_LINKS.map(link => (
-                    <BulletUrlLink
-                        path={link.url}
-                        key={NAV_DETAILED_PREFIX + link.url}
-                        icon={link.icon}
-                        description={link.description}
-                    />
-                ))}
-
-                {PATH_LINKS.map(link => (
-                    <BulletPageLink
-                        key={NAV_DETAILED_PREFIX + link.path}
-                        link={link}
-                        showDesc={true}
-                    />
-                ))}
-            </ul>
-        </nav>
-    </footer>
-)
-
-const Nav = () => <NavBullets />
 
 export { Nav, NavDetailed }

--- a/src/components/generic/SmallWidgets.js
+++ b/src/components/generic/SmallWidgets.js
@@ -1,5 +1,6 @@
 import React from "react"
-import { ICON_COMPONENTS, RESET_LABEL } from "../vars"
+import { ICON_COMPONENTS } from "../vars"
+import translations from "../../translations"
 
 const AlertBox = ({ info }) => (
     <div className="message">
@@ -37,8 +38,8 @@ const BasicButton = ({ handleClick, children }) => (
     </button>
 )
 
-const ResetButton = ({ reset }) => (
-    <BasicButton handleClick={reset}>{RESET_LABEL}</BasicButton>
+const ResetButton = ({ reset, language }) => (
+    <BasicButton handleClick={reset}>{translations[language].reset}</BasicButton>
 )
 
 export { AlertBox, Card, ToggleSwitch, BasicButton, ResetButton }

--- a/src/components/pages/ForwardKinematicsPage.js
+++ b/src/components/pages/ForwardKinematicsPage.js
@@ -2,10 +2,11 @@ import React, { Component } from "react"
 import LegPoseWidget from "../pagePartials/LegPoseWidgets"
 import { Card, ToggleSwitch, ResetButton, NumberInputField, Slider } from "../generic"
 import { DEFAULT_POSE } from "../../templates"
-import { SECTION_NAMES, LEG_NAMES } from "../vars"
+import { LEG_NAMES } from "../vars"
+import translations from "../../translations"
 
 class ForwardKinematicsPage extends Component {
-    pageName = SECTION_NAMES.forwardKinematics
+    pageName = "forwardKinematics"
     state = { WidgetType: NumberInputField }
 
     componentDidMount = () => this.props.onMount(this.pageName)
@@ -38,9 +39,14 @@ class ForwardKinematicsPage extends Component {
     )
 
     get toggleSwitch() {
+        const { language } = this.props
+        const value =
+            this.state.WidgetType === Slider
+                ? translations[language].forwardKinematics.slide
+                : translations[language].forwardKinematics.input
         const props = {
             id: "FwdKinematicsSwitch",
-            value: this.state.WidgetType === Slider ? "Slide" : "Input",
+            value,
             handleChange: this.toggleMode,
             showValue: true,
         }
@@ -48,14 +54,18 @@ class ForwardKinematicsPage extends Component {
         return <ToggleSwitch {...props} />
     }
 
-    render = () => (
-        <Card title={<h2>{this.pageName}</h2>} other={this.toggleSwitch}>
-            <div className="grid-cols-2">
-                {LEG_NAMES.map(name => this.legPoseWidget(name))}
-            </div>
-            <ResetButton reset={this.reset} />
-        </Card>
-    )
+    render = () => {
+        const { language } = this.props
+        const title = translations[language].sections[this.pageName]
+        return (
+            <Card title={<h2>{title}</h2>} other={this.toggleSwitch}>
+                <div className="grid-cols-2">
+                    {LEG_NAMES.map(name => this.legPoseWidget(name))}
+                </div>
+                <ResetButton reset={this.reset} language={language} />
+            </Card>
+        )
+    }
 }
 
 export default ForwardKinematicsPage

--- a/src/components/pages/InverseKinematicsPage.js
+++ b/src/components/pages/InverseKinematicsPage.js
@@ -1,12 +1,13 @@
 import React, { Component } from "react"
 import { sliderList, Card, ResetButton, AlertBox } from "../generic"
 import { solveInverseKinematics } from "../../hexapod"
-import { SECTION_NAMES, IK_SLIDERS_LABELS } from "../vars"
+import { IK_SLIDERS_LABELS } from "../vars"
 import { DEFAULT_IK_PARAMS } from "../../templates"
 import PoseTable from "../pagePartials/PoseTable"
+import translations from "../../translations"
 
 class InverseKinematicsPage extends Component {
-    pageName = SECTION_NAMES.inverseKinematics
+    pageName = "inverseKinematics"
     state = { ikParams: DEFAULT_IK_PARAMS, errorMessage: null }
 
     componentDidMount = () => this.props.onMount(this.pageName)
@@ -53,14 +54,18 @@ class InverseKinematicsPage extends Component {
         return <PoseTable pose={this.props.params.pose} />
     }
 
-    render = () => (
-        <Card title={<h2>{this.pageName}</h2>}>
-            <div className="grid-cols-3">{this.sliders.slice(0, 6)}</div>
-            <div className="grid-cols-2">{this.sliders.slice(6, 8)}</div>
-            <ResetButton reset={this.reset} />
-            {this.additionalInfo}
-        </Card>
-    )
+    render = () => {
+        const { language } = this.props
+        const title = translations[language].sections[this.pageName]
+        return (
+            <Card title={<h2>{title}</h2>}>
+                <div className="grid-cols-3">{this.sliders.slice(0, 6)}</div>
+                <div className="grid-cols-2">{this.sliders.slice(6, 8)}</div>
+                <ResetButton reset={this.reset} language={language} />
+                {this.additionalInfo}
+            </Card>
+        )
+    }
 }
 
 export default InverseKinematicsPage

--- a/src/components/pages/LandingPage.js
+++ b/src/components/pages/LandingPage.js
@@ -1,29 +1,26 @@
 import React from "react"
-import { SECTION_NAMES } from "../vars"
 import RandomRobotGif from "../pagePartials/RandomRobotGif"
+import translations from "../../translations"
 
 class LandingPage extends React.Component {
-    pageName = SECTION_NAMES.landingPage
+    pageName = "landingPage"
 
     componentDidMount = () => this.props.onMount(this.pageName)
 
-    render = () => (
-        <>
-            <div id="landing">
-                <RandomRobotGif />
-                <h1>Mithi's Bare Minimum Hexapod Robot Simulator</h1>
-                <p>
-                    This page might feel slow at first, because it is also eagerly loading
-                    and mounting the 3d plot behind the scenes! You can actually already
-                    navigate to any of the links below right now (which I recommend), even
-                    if this page hasn't fully loaded yet.
-                </p>
-                <p>
-                    This app works offline! Enjoy your stay and share with your friends!
-                </p>
-            </div>
-        </>
-    )
+    render = () => {
+        const { language } = this.props
+        const t = translations[language].landing
+        return (
+            <>
+                <div id="landing">
+                    <RandomRobotGif />
+                    <h1>{t.title}</h1>
+                    <p>{t.p1}</p>
+                    <p>{t.p2}</p>
+                </div>
+            </>
+        )
+    }
 }
 
 export default LandingPage

--- a/src/components/pages/LegPatternPage.js
+++ b/src/components/pages/LegPatternPage.js
@@ -1,10 +1,11 @@
 import React, { Component } from "react"
 import { sliderList, Card, ResetButton } from "../generic"
 import { DEFAULT_POSE, DEFAULT_PATTERN_PARAMS } from "../../templates"
-import { SECTION_NAMES, ANGLE_NAMES } from "../vars"
+import { ANGLE_NAMES } from "../vars"
+import translations from "../../translations"
 
 class LegPatternPage extends Component {
-    pageName = SECTION_NAMES.legPatterns
+    pageName = "legPatterns"
     state = { patternParams: DEFAULT_PATTERN_PARAMS }
 
     componentDidMount = () => {
@@ -37,12 +38,16 @@ class LegPatternPage extends Component {
         })
     }
 
-    render = () => (
-        <Card title={<h2>{this.pageName}</h2>}>
-            <div className="grid-cols-1">{this.sliders}</div>
-            <ResetButton reset={this.reset} />
-        </Card>
-    )
+    render = () => {
+        const { language } = this.props
+        const title = translations[language].sections[this.pageName]
+        return (
+            <Card title={<h2>{title}</h2>}>
+                <div className="grid-cols-1">{this.sliders}</div>
+                <ResetButton reset={this.reset} language={language} />
+            </Card>
+        )
+    }
 }
 
 export default LegPatternPage

--- a/src/components/pages/WalkingGaitsPage.js
+++ b/src/components/pages/WalkingGaitsPage.js
@@ -1,11 +1,12 @@
 import React, { Component } from "react"
 import { sliderList, Card, ResetButton, ToggleSwitch } from "../generic"
-import { SECTION_NAMES, GAIT_SLIDER_LABELS, GAIT_RANGE_PARAMS } from "../vars"
+import { GAIT_SLIDER_LABELS, GAIT_RANGE_PARAMS } from "../vars"
 import getWalkSequence from "../../hexapod/solvers/walkSequenceSolver"
 import PoseTable from "../pagePartials/PoseTable"
 import { VirtualHexapod } from "../../hexapod"
 import { tRotZmatrix } from "../../hexapod/geometry"
 import { DEFAULT_GAIT_PARAMS } from "../../templates"
+import translations from "../../translations"
 
 const ANIMATION_DELAY = 25
 
@@ -32,7 +33,7 @@ const switches = (switch1, switch2, switch3) => (
 const countSteps = sequence => sequence["leftMiddle"].alpha.length
 
 class WalkingGaitsPage extends Component {
-    pageName = SECTION_NAMES.walkingGaits
+    pageName = "walkingGaits"
     currentTwist = 0
     walkSequence = null
     state = {
@@ -151,27 +152,41 @@ class WalkingGaitsPage extends Component {
     }
 
     get widgetsSwitch() {
-        const value = this.state.showGaitWidgets ? "controlsShown" : "poseShown"
+        const { language } = this.props
+        const { walking } = translations[language]
+        const value = this.state.showGaitWidgets
+            ? walking.controlsShown
+            : walking.poseShown
         return newSwitch("widgetSw", value, this.toggleWidgets)
     }
 
     get animatingSwitch() {
-        const value = this.state.isAnimating ? "PLAYING..." : "...PAUSED. "
+        const { language } = this.props
+        const { walking } = translations[language]
+        const value = this.state.isAnimating ? walking.playing : walking.paused
         return newSwitch("animatingSw", value, this.toggleAnimating)
     }
 
     get gaitTypeSwitch() {
-        const value = this.state.isTripodGait ? "tripodGait" : "rippleGait"
+        const { language } = this.props
+        const { walking } = translations[language]
+        const value = this.state.isTripodGait
+            ? walking.tripodGait
+            : walking.rippleGait
         return newSwitch("gaitSw", value, this.toggleGaitType)
     }
 
     get directionSwitch() {
-        const value = this.state.isForward ? "isForward" : "isBackward"
+        const { language } = this.props
+        const { walking } = translations[language]
+        const value = this.state.isForward ? walking.isForward : walking.isBackward
         return newSwitch("directionSw", value, this.toggleDirection)
     }
 
     get rotateSwitch() {
-        const value = this.state.inWalkMode ? "isWalk" : "isRotate"
+        const { language } = this.props
+        const { walking } = translations[language]
+        const value = this.state.inWalkMode ? walking.isWalk : walking.isRotate
         return newSwitch("rotateSw", value, this.toggleWalkMode)
     }
 
@@ -209,14 +224,16 @@ class WalkingGaitsPage extends Component {
         const { showGaitWidgets } = this.state
         const { pose } = this.props.params
 
+        const { language } = this.props
+        const title = translations[language].sections[this.pageName]
         return (
-            <Card title={<h2>{this.pageName}</h2>} other={this.animationCount}>
+            <Card title={<h2>{title}</h2>} other={this.animationCount}>
                 {animationControlSwitches}
 
                 <div hidden={!showGaitWidgets}>
                     {gaitControlSwitches}
                     {this.sliders}
-                    <ResetButton reset={this.reset} />
+                    <ResetButton reset={this.reset} language={language} />
                 </div>
 
                 <div hidden={showGaitWidgets}>

--- a/src/components/vars.js
+++ b/src/components/vars.js
@@ -2,15 +2,7 @@ import React from "react"
 import { GiCoffeeMug } from "react-icons/gi"
 import { FaGithubAlt, FaTimes, FaHome } from "react-icons/fa"
 import { GrStatusGoodSmall } from "react-icons/gr"
-
-const SECTION_NAMES = {
-    dimensions: "Dimensions",
-    inverseKinematics: "Inverse Kinematics",
-    forwardKinematics: "Forward Kinematics",
-    legPatterns: "Leg Patterns",
-    landingPage: "Root",
-    walkingGaits: "Walking Gaits",
-}
+import translations from "../translations"
 
 const PATH_NAMES = {
     inverseKinematics: "/inverse-kinematics",
@@ -32,7 +24,6 @@ const LEG_NAMES = [
 ]
 
 const IK_SLIDERS_LABELS = ["tx", "ty", "tz", "rx", "ry", "rz", "hipStance", "legStance"]
-const RESET_LABEL = "reset"
 
 const GAIT_SLIDER_LABELS = [
     "hipSwing",
@@ -87,6 +78,7 @@ const GAIT_RANGE_PARAMS = {
     liftSwing: { minVal: 10, maxVal: 70, stepVal: 0.5, defaultVal: 40 },
     stepCount: { minVal: 3, maxVal: 7, stepVal: 1, defaultVal: 5 },
 }
+
 /*************
  * ICONS
  *************/
@@ -99,87 +91,61 @@ const ICON_COMPONENTS = {
     home: <FaHome className="vertical-align" />,
 }
 
-/*************
- * NAVIGATION
- *************/
-
-const PATHS = {
-    inverseKinematics: {
-        path: PATH_NAMES.inverseKinematics,
-        description: SECTION_NAMES.inverseKinematics,
-        icon: ICON_COMPONENTS.circle,
-    },
-    forwardKinematics: {
-        path: PATH_NAMES.forwardKinematics,
-        description: SECTION_NAMES.forwardKinematics,
-        icon: ICON_COMPONENTS.circle,
-    },
-    legPatterns: {
-        path: PATH_NAMES.legPatterns,
-        description: SECTION_NAMES.legPatterns,
-        icon: ICON_COMPONENTS.circle,
-    },
-    landingPage: {
-        path: PATH_NAMES.landingPage,
-        description: SECTION_NAMES.landingPage,
-        icon: ICON_COMPONENTS.home,
-    },
-
-    walkingGaits: {
-        path: PATH_NAMES.walkingGaits,
-        description: SECTION_NAMES.walkingGaits,
-        icon: ICON_COMPONENTS.circle,
-    },
-}
-
-const KOFI_LINK_PROPERTIES = {
-    name: "KOFI",
-    icon: ICON_COMPONENTS.mug,
-    description: "Buy Mithi Ko-Fi 🍵",
-    url: "https://ko-fi.com/minimithi",
-}
-
-const REPO_LINK_PROPERTIES = {
-    name: "REPO",
-    icon: ICON_COMPONENTS.octocat,
-    description: "Source Code",
-    url: "https://github.com/mithi/hexapod",
-}
+/* Default Spanish navigation links for tests and other utilities */
+const t = translations.es
 
 const PATH_LINKS = [
-    PATHS.inverseKinematics,
-    PATHS.forwardKinematics,
-    PATHS.legPatterns,
-    PATHS.walkingGaits,
-    PATHS.landingPage,
+    {
+        path: PATH_NAMES.inverseKinematics,
+        description: t.sections.inverseKinematics,
+        icon: ICON_COMPONENTS.circle,
+    },
+    {
+        path: PATH_NAMES.forwardKinematics,
+        description: t.sections.forwardKinematics,
+        icon: ICON_COMPONENTS.circle,
+    },
+    {
+        path: PATH_NAMES.legPatterns,
+        description: t.sections.legPatterns,
+        icon: ICON_COMPONENTS.circle,
+    },
+    {
+        path: PATH_NAMES.walkingGaits,
+        description: t.sections.walkingGaits,
+        icon: ICON_COMPONENTS.circle,
+    },
+    {
+        path: PATH_NAMES.landingPage,
+        description: t.sections.landingPage,
+        icon: ICON_COMPONENTS.home,
+    },
 ]
 
-const URL_LINKS = [KOFI_LINK_PROPERTIES, REPO_LINK_PROPERTIES]
-
-/*************
- * LANDING PAGE
- *************/
-
-const LANDING_PAGE_MESSAGE = `
-
-# Mithi's Bare Minimum Hexapod Robot Simulator
-
-Enjoy your stay and share with your friends!
-`
+const URL_LINKS = [
+    {
+        url: "https://ko-fi.com/minimithi",
+        icon: ICON_COMPONENTS.mug,
+        description: t.nav.kofi,
+    },
+    {
+        url: "https://github.com/mithi/hexapod",
+        icon: ICON_COMPONENTS.octocat,
+        description: t.nav.repo,
+    },
+]
 
 export {
-    ICON_COMPONENTS,
-    LANDING_PAGE_MESSAGE,
-    SECTION_NAMES,
+    PATH_NAMES,
     ANGLE_NAMES,
     DIMENSION_NAMES,
     LEG_NAMES,
     IK_SLIDERS_LABELS,
     GAIT_SLIDER_LABELS,
-    RESET_LABEL,
-    PATHS,
-    URL_LINKS,
-    PATH_LINKS,
     RANGE_PARAMS,
     GAIT_RANGE_PARAMS,
+    ICON_COMPONENTS,
+    PATH_LINKS,
+    URL_LINKS,
 }
+

--- a/src/tests/components/App.test.js
+++ b/src/tests/components/App.test.js
@@ -23,7 +23,7 @@ Default Dimensions Widget
  * * * */
 
 const expectToHaveDefaultDimensionsWidget = () => {
-    const heading = screen.getByRole("heading", { name: "Dimensions" })
+    const heading = screen.getByRole("heading", { name: "Dimensiones" })
     expect(heading).toBeInTheDocument()
 
     const dimensions = ["front", "middle", "side", "femur", "coxia", "tibia"]
@@ -49,7 +49,7 @@ Default Leg Patterns Page
  * * * */
 
 const expectToHaveDefaultLegPatternsPage = () => {
-    const heading = screen.getByRole("heading", { name: "Leg Patterns" })
+    const heading = screen.getByRole("heading", { name: "Patrones de patas" })
     expect(heading).toBeInTheDocument()
     const sliderNames = ["alpha", "beta", "gamma"]
 
@@ -67,7 +67,7 @@ Default Inverse Kinematics Page
  * * * */
 
 const expectToHaveDefaultInverseKinematics = () => {
-    const heading = screen.getByRole("heading", { name: "Inverse Kinematics" })
+    const heading = screen.getByRole("heading", { name: "Cinemática inversa" })
     expect(heading).toBeInTheDocument()
 
     const attributes = [
@@ -104,7 +104,7 @@ Default Forward Kinematics Page
  * * * */
 
 const expectToHaveDefaultForwardKinematics = () => {
-    const heading = screen.getByRole("heading", { name: "Forward Kinematics" })
+    const heading = screen.getByRole("heading", { name: "Cinemática directa" })
     expect(heading).toBeInTheDocument()
 
     const angles = ["alpha", "beta", "gamma"]
@@ -137,7 +137,7 @@ Elements all pages share
 const expectEachPage = (
     flags = { numberOfResetButtons: 2, numberOfToggleSwitches: 1 }
 ) => {
-    const resetButtons = screen.getAllByRole("button", { name: "reset" })
+    const resetButtons = screen.getAllByRole("button", { name: "Reiniciar" })
     const toggleSwitches = screen.getAllByRole("checkbox")
     expect(resetButtons).toHaveLength(flags.numberOfResetButtons)
     expect(toggleSwitches).toHaveLength(flags.numberOfToggleSwitches)
@@ -157,35 +157,35 @@ describe("App", () => {
     })
 
     test("Navigates to Leg Patterns page", () => {
-        click("Leg Patterns")
+        click("Patrones de patas")
         expectEachPage()
         expectToHaveDefaultLegPatternsPage()
     })
 
     test("Navigates to Inverse Kinematics page", () => {
-        click("Inverse Kinematics")
+        click("Cinemática inversa")
         expectEachPage()
         expectToHaveDefaultInverseKinematics()
     })
 
     test("Navigates to Forward Kinematics page", () => {
-        click("Forward Kinematics")
+        click("Cinemática directa")
         expectEachPage({ numberOfResetButtons: 2, numberOfToggleSwitches: 2 })
         expectToHaveDefaultForwardKinematics()
     })
 
     test("Navigates to Landing Page", () => {
-        click("Root")
+        click("Inicio")
         const heading = screen.getByRole("heading", {
-            name: "Mithi's Bare Minimum Hexapod Robot Simulator",
+            name: "Simulador de robot hexápodo mínimo de Mithi",
         })
         expect(heading).toBeInTheDocument()
 
         const wrongHeadings = [
-            "Dimensions",
-            "Leg Patterns",
-            "Inverse Kinematics",
-            "Forward Kinematics",
+            "Dimensiones",
+            "Patrones de patas",
+            "Cinemática inversa",
+            "Cinemática directa",
         ]
         wrongHeadings.forEach(name =>
             expect(screen.queryByRole("heading", { name })).toBeNull()

--- a/src/tests/components/DimensionWidget.test.js
+++ b/src/tests/components/DimensionWidget.test.js
@@ -14,10 +14,10 @@ const DIMENSIONS = {
 describe("Dimension Widget", () => {
     test("renders component correctly", () => {
         render(<DimensionsWidget params={{ dimensions: DIMENSIONS }} />)
-        expect(screen.getByRole("heading")).toHaveTextContent("Dimensions")
+        expect(screen.getByRole("heading")).toHaveTextContent("Dimensiones")
         expect(screen.getByRole("checkbox")).toBeInTheDocument()
 
-        const button = screen.getByRole("button", { name: "reset" })
+        const button = screen.getByRole("button", { name: "Reiniciar" })
         expect(button).toBeInTheDocument()
 
         Object.entries(DIMENSIONS).forEach(([name, value]) => {

--- a/src/translations.js
+++ b/src/translations.js
@@ -1,0 +1,76 @@
+const translations = {
+    es: {
+        sections: {
+            dimensions: "Dimensiones",
+            inverseKinematics: "Cinemática inversa",
+            forwardKinematics: "Cinemática directa",
+            legPatterns: "Patrones de patas",
+            landingPage: "Inicio",
+            walkingGaits: "Marchas de caminata",
+        },
+        nav: {
+            kofi: "Compra un Ko-Fi a Mithi 🍵",
+            repo: "Código fuente",
+        },
+        landing: {
+            title: "Simulador de robot hexápodo mínimo de Mithi",
+            p1: "Esta página puede sentirse lenta al principio porque también está cargando y montando con anticipación la trama 3D detrás de escena. ¡Puedes navegar a cualquiera de los enlaces de abajo ahora mismo (lo recomiendo), incluso si esta página aún no se ha cargado completamente!",
+            p2: "¡Esta aplicación funciona sin conexión! ¡Disfruta tu visita y comparte con tus amigos!",
+        },
+        reset: "Reiniciar",
+        forwardKinematics: {
+            slide: "Deslizar",
+            input: "Entrada",
+        },
+        walking: {
+            controlsShown: "Controles",
+            poseShown: "Poses",
+            playing: "REPRODUCIENDO...",
+            paused: "...PAUSADO.",
+            tripodGait: "Marcha trípode",
+            rippleGait: "Marcha ondulatoria",
+            isForward: "Adelante",
+            isBackward: "Atrás",
+            isWalk: "Caminar",
+            isRotate: "Girar",
+        },
+    },
+    en: {
+        sections: {
+            dimensions: "Dimensions",
+            inverseKinematics: "Inverse Kinematics",
+            forwardKinematics: "Forward Kinematics",
+            legPatterns: "Leg Patterns",
+            landingPage: "Home",
+            walkingGaits: "Walking Gaits",
+        },
+        nav: {
+            kofi: "Buy Mithi Ko-Fi 🍵",
+            repo: "Source Code",
+        },
+        landing: {
+            title: "Mithi's Bare Minimum Hexapod Robot Simulator",
+            p1: "This page might feel slow at first, because it is also eagerly loading and mounting the 3d plot behind the scenes! You can actually already navigate to any of the links below right now (which I recommend), even if this page hasn't fully loaded yet.",
+            p2: "This app works offline! Enjoy your stay and share with your friends!",
+        },
+        reset: "reset",
+        forwardKinematics: {
+            slide: "Slide",
+            input: "Input",
+        },
+        walking: {
+            controlsShown: "Controls",
+            poseShown: "Pose",
+            playing: "PLAYING...",
+            paused: "...PAUSED.",
+            tripodGait: "Tripod Gait",
+            rippleGait: "Ripple Gait",
+            isForward: "Forward",
+            isBackward: "Backward",
+            isWalk: "Walk",
+            isRotate: "Rotate",
+        },
+    },
+}
+
+export default translations


### PR DESCRIPTION
## Summary
- add language toggle with English/Spanish support
- translate navigation, pages, and tests to Spanish

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68913e3cc2308324af642642533c46fd