### PR TITLE
Place language switch on top navigation bar

### DIFF
--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -95,7 +95,7 @@ const NavBullets = ({ language, toggleLanguage }) => {
                 <BulletPageLink key={NAV_BULLETS_PREFIX + link.path} link={link} />
             ))}
 
-            <li>
+            <li className="language-button">
                 <button
                     onClick={toggleLanguage}
                     className="link-icon"

--- a/src/index.css
+++ b/src/index.css
@@ -141,11 +141,14 @@ tr:hover {
 }
 
 #top-bar {
-    display: grid;
-    grid-template-columns: auto auto auto auto auto auto 1fr;
+    display: flex;
     list-style-type: none;
     margin: 0px;
     padding-left: 0px;
+}
+
+#top-bar .language-button {
+    margin-left: auto;
 }
 
 .link-icon {


### PR DESCRIPTION
## Summary
- keep language toggle in NavBullets and align with top navigation buttons
- update top bar styles to flex and push toggle to the right

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68914e3bd71483248accec0582bcc3f4