### PR TITLE
feat: add basic arms control menu

### DIFF
--- a/src/components/ArmsMenu.js
+++ b/src/components/ArmsMenu.js
@@ -1,0 +1,41 @@
+import React, { useState } from "react"
+import { Card } from "./generic/SmallWidgets"
+import translations from "../translations"
+
+const ArmsMenu = ({ language = "es" }) => {
+    const t = translations[language]
+    const [selectedArm, setSelectedArm] = useState("both")
+    const [direction, setDirection] = useState("same")
+
+    const sectionName = t.sections.armsControl
+
+    return (
+        <Card title={<h2>{sectionName}</h2>}>
+            <div className="grid-cols-2">
+                <label>
+                    {t.arms.selectArm}
+                    <select
+                        value={selectedArm}
+                        onChange={e => setSelectedArm(e.target.value)}
+                    >
+                        <option value="left">{t.arms.left}</option>
+                        <option value="right">{t.arms.right}</option>
+                        <option value="both">{t.arms.both}</option>
+                    </select>
+                </label>
+                <label>
+                    {t.arms.direction}
+                    <select
+                        value={direction}
+                        onChange={e => setDirection(e.target.value)}
+                    >
+                        <option value="same">{t.arms.same}</option>
+                        <option value="opposite">{t.arms.opposite}</option>
+                    </select>
+                </label>
+            </div>
+        </Card>
+    )
+}
+
+export default ArmsMenu

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,4 +1,6 @@
 import { Nav, NavDetailed } from "./Nav"
 import HexapodPlot from "./HexapodPlot"
 import DimensionsWidget from "./DimensionsWidget"
-export { Nav, NavDetailed, HexapodPlot, DimensionsWidget }
+import ArmsMenu from "./ArmsMenu"
+
+export { Nav, NavDetailed, HexapodPlot, DimensionsWidget, ArmsMenu }

--- a/src/components/pages/ForwardKinematicsPage.js
+++ b/src/components/pages/ForwardKinematicsPage.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react"
 import LegPoseWidget from "../pagePartials/LegPoseWidgets"
 import { Card, ToggleSwitch, ResetButton, NumberInputField, Slider } from "../generic"
+import ArmsMenu from "../ArmsMenu"
 import { DEFAULT_POSE } from "../../templates"
 import { LEG_NAMES } from "../vars"
 import translations from "../../translations"
@@ -58,12 +59,15 @@ class ForwardKinematicsPage extends Component {
         const { language } = this.props
         const title = translations[language].sections[this.pageName]
         return (
-            <Card title={<h2>{title}</h2>} other={this.toggleSwitch}>
-                <div className="grid-cols-2">
-                    {LEG_NAMES.map(name => this.legPoseWidget(name))}
-                </div>
-                <ResetButton reset={this.reset} language={language} />
-            </Card>
+            <>
+                <Card title={<h2>{title}</h2>} other={this.toggleSwitch}>
+                    <div className="grid-cols-2">
+                        {LEG_NAMES.map(name => this.legPoseWidget(name))}
+                    </div>
+                    <ResetButton reset={this.reset} language={language} />
+                </Card>
+                <ArmsMenu language={language} />
+            </>
         )
     }
 }

--- a/src/components/pages/InverseKinematicsPage.js
+++ b/src/components/pages/InverseKinematicsPage.js
@@ -5,6 +5,7 @@ import { IK_SLIDERS_LABELS } from "../vars"
 import { DEFAULT_IK_PARAMS } from "../../templates"
 import PoseTable from "../pagePartials/PoseTable"
 import translations from "../../translations"
+import ArmsMenu from "../ArmsMenu"
 
 class InverseKinematicsPage extends Component {
     pageName = "inverseKinematics"
@@ -58,12 +59,15 @@ class InverseKinematicsPage extends Component {
         const { language } = this.props
         const title = translations[language].sections[this.pageName]
         return (
-            <Card title={<h2>{title}</h2>}>
-                <div className="grid-cols-3">{this.sliders.slice(0, 6)}</div>
-                <div className="grid-cols-2">{this.sliders.slice(6, 8)}</div>
-                <ResetButton reset={this.reset} language={language} />
-                {this.additionalInfo}
-            </Card>
+            <>
+                <Card title={<h2>{title}</h2>}>
+                    <div className="grid-cols-3">{this.sliders.slice(0, 6)}</div>
+                    <div className="grid-cols-2">{this.sliders.slice(6, 8)}</div>
+                    <ResetButton reset={this.reset} language={language} />
+                    {this.additionalInfo}
+                </Card>
+                <ArmsMenu language={language} />
+            </>
         )
     }
 }

--- a/src/components/vars.js
+++ b/src/components/vars.js
@@ -22,6 +22,7 @@ const LEG_NAMES = [
     "leftBack",
     "rightBack",
 ]
+const ARM_NAMES = ["leftArm", "rightArm"]
 
 const IK_SLIDERS_LABELS = ["tx", "ty", "tz", "rx", "ry", "rz", "hipStance", "legStance"]
 
@@ -140,6 +141,7 @@ export {
     ANGLE_NAMES,
     DIMENSION_NAMES,
     LEG_NAMES,
+    ARM_NAMES,
     IK_SLIDERS_LABELS,
     GAIT_SLIDER_LABELS,
     RANGE_PARAMS,
@@ -148,4 +150,3 @@ export {
     PATH_LINKS,
     URL_LINKS,
 }
-

--- a/src/translations.js
+++ b/src/translations.js
@@ -7,6 +7,7 @@ const translations = {
             legPatterns: "Patrones de patas",
             landingPage: "Inicio",
             walkingGaits: "Marchas de caminata",
+            armsControl: "Control de brazos",
         },
         nav: {
             kofi: "Compra un Ko-Fi a Mithi 🍵",
@@ -34,6 +35,15 @@ const translations = {
             isWalk: "Caminar",
             isRotate: "Girar",
         },
+        arms: {
+            selectArm: "Seleccionar Brazo",
+            left: "Izquierdo",
+            right: "Derecho",
+            both: "Ambos",
+            direction: "Dirección",
+            same: "Igual",
+            opposite: "Opuesta",
+        },
     },
     en: {
         sections: {
@@ -43,6 +53,7 @@ const translations = {
             legPatterns: "Leg Patterns",
             landingPage: "Home",
             walkingGaits: "Walking Gaits",
+            armsControl: "Arm Control",
         },
         nav: {
             kofi: "Buy Mithi Ko-Fi 🍵",
@@ -69,6 +80,15 @@ const translations = {
             isBackward: "Backward",
             isWalk: "Walk",
             isRotate: "Rotate",
+        },
+        arms: {
+            selectArm: "Select Arm",
+            left: "Left",
+            right: "Right",
+            both: "Both",
+            direction: "Direction",
+            same: "Same",
+            opposite: "Opposite",
         },
     },
 }


### PR DESCRIPTION
## Summary
- add placeholder arms menu with options for left, right, or both arms
- include English and Spanish translations and expose component
- render arm controls on forward and inverse kinematics pages

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_689153f5b4f08324ba544f2922048429