### PR TITLE
Keep arm beta at 80 degrees by default

### DIFF
--- a/src/hexapod/VirtualHexapod.js
+++ b/src/hexapod/VirtualHexapod.js
@@ -132,7 +132,8 @@ class VirtualHexapod {
         pose,
         flags = { hasNoPoints: false, assumeKnownGroundPoints: false, wontRotate: false }
     ) {
-        Object.assign(this, { dimensions, pose })
+        const completePose = { ...DEFAULT_POSE, ...pose }
+        Object.assign(this, { dimensions, pose: completePose })
 
         if (flags.hasNoPoints) {
             return

--- a/src/templates/hexapodParams.js
+++ b/src/templates/hexapodParams.js
@@ -34,8 +34,8 @@ const DEFAULT_POSE = {
     rightMiddle: { alpha: 0, beta: 0, gamma: 0 },
     leftBack: { alpha: 0, beta: 0, gamma: 0 },
     rightBack: { alpha: 0, beta: 0, gamma: 0 },
-    leftArm: { alpha: 0, beta: 0, gamma: 0 },
-    rightArm: { alpha: 0, beta: 0, gamma: 0 },
+    leftArm: { alpha: 0, beta: 80, gamma: 0 },
+    rightArm: { alpha: 0, beta: 80, gamma: 0 },
 }
 
 const DEFAULT_PATTERN_PARAMS = { alpha: 0, beta: 0, gamma: 0 }


### PR DESCRIPTION
## Summary
- Set default arm beta angle to 80 degrees
- Ensure VirtualHexapod applies default pose when arm pose not provided

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68916cb055008324bc6aca5e019baa7f