### PR TITLE
Add adjustable five-segment tail to hexapod simulator

### DIFF
--- a/src/components/vars.js
+++ b/src/components/vars.js
@@ -26,6 +26,13 @@ const DIMENSION_NAMES = [
     "armCoxia",
     "armFemur",
     "armTibia",
+    "tailSegment1",
+    "tailSegment2",
+    "tailSegment3",
+    "tailSegment4",
+    "tailSegment5",
+    "tailThickness",
+    "tailMountAngle",
 ]
 const LEG_NAMES = [
     "leftFront",

--- a/src/hexapod/Tail.js
+++ b/src/hexapod/Tail.js
@@ -18,10 +18,10 @@ class Tail {
     }
 
     _computePoints() {
-        const { segments } = this.dimensions
+        const { segments, mountAngle = 0 } = this.dimensions
         const { yaw, theta1, theta2, theta3, theta4, theta5 } = this.pose
         const angles = [theta1, theta2, theta3, theta4, theta5]
-        const yawRad = degToRad(yaw)
+        const yawRad = degToRad(yaw + mountAngle)
         let cumulative = 0
         let x = this.originPoint.x
         let y = this.originPoint.y
@@ -57,12 +57,9 @@ class Tail {
     }
 
     _buildClone(allPointsList) {
-        const clone = new Tail(
-            this.dimensions,
-            this.originPoint,
-            this.pose,
-            { hasNoPoints: true }
-        )
+        const clone = new Tail(this.dimensions, this.originPoint, this.pose, {
+            hasNoPoints: true,
+        })
         clone.allPointsList = allPointsList
         return clone
     }
@@ -140,4 +137,3 @@ class Tail {
 }
 
 export default Tail
-

--- a/src/templates/hexapodParams.js
+++ b/src/templates/hexapodParams.js
@@ -31,6 +31,13 @@ const DEFAULT_DIMENSIONS = {
     armCoxia: 80,
     armFemur: 80,
     armTibia: 80,
+    tailSegment1: 80,
+    tailSegment2: 80,
+    tailSegment3: 80,
+    tailSegment4: 80,
+    tailSegment5: 80,
+    tailThickness: 20,
+    tailMountAngle: 0,
 }
 
 const DEFAULT_POSE = {

--- a/src/templates/plotter.js
+++ b/src/templates/plotter.js
@@ -9,7 +9,7 @@ const _drawHexapod = hexapod => {
     const bodyY = polygonVertices.map(point => point.y)
     const bodyZ = polygonVertices.map(point => point.z)
     const { head, cog } = hexapod.body
-    const { cogProjection, legs, arms = [], groundContactPoints } = hexapod
+    const { cogProjection, legs, arms = [], tail, groundContactPoints } = hexapod
 
     const dBodyMesh = {
         ...DATA[0],
@@ -60,6 +60,14 @@ const _drawHexapod = hexapod => {
         y: arm.allPointsList.map(point => point.y),
         z: arm.allPointsList.map(point => point.z),
     }))
+
+    const dTail = {
+        ...DATA[5],
+        name: "tail",
+        x: tail.allPointsList.map(point => point.x),
+        y: tail.allPointsList.map(point => point.y),
+        z: tail.allPointsList.map(point => point.z),
+    }
 
     const dSupportPolygon = {
         ...DATA[11],
@@ -114,6 +122,7 @@ const _drawHexapod = hexapod => {
         dCogProjection,
         ...dLegs,
         ...dArms,
+        dTail,
         dSupportPolygon,
         hXaxis,
         hYaxis,


### PR DESCRIPTION
## Summary
- add tail segment length, thickness, and mount angle to robot dimensions
- render articulated tail in VirtualHexapod and 3D plot
- support yaw offset via mount angle

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891759ba1b08324814b26a4a4e378fe