### PR TITLE
Add arm and tail dimension controls

### DIFF
--- a/src/components/DimensionsWidget.js
+++ b/src/components/DimensionsWidget.js
@@ -9,7 +9,13 @@ class DimensionsWidget extends Component {
     sectionKey = "dimensions"
     state = { isFine: true }
 
-    reset = () => this.props.onUpdate("dimensions", { dimensions: DEFAULT_DIMENSIONS })
+    reset = () => {
+        const dimensions = { ...this.props.params.dimensions }
+        DIMENSION_NAMES.forEach(name => {
+            dimensions[name] = DEFAULT_DIMENSIONS[name]
+        })
+        this.props.onUpdate("dimensions", { dimensions })
+    }
 
     toggleMode = () => this.setState({ isFine: !this.state.isFine })
 

--- a/src/components/pages/ArmControlPage.js
+++ b/src/components/pages/ArmControlPage.js
@@ -1,8 +1,9 @@
 import React, { Component } from "react"
 import LegPoseWidget from "../pagePartials/LegPoseWidgets"
 import { Card, ResetButton, ToggleSwitch, NumberInputField, Slider } from "../generic"
-import { DEFAULT_POSE } from "../../templates"
+import { DEFAULT_POSE, DEFAULT_DIMENSIONS } from "../../templates"
 import translations from "../../translations"
+import { ARM_DIMENSION_NAMES, RANGE_PARAMS } from "../vars"
 
 class ArmControlPage extends Component {
     pageName = "armControl"
@@ -10,7 +11,22 @@ class ArmControlPage extends Component {
 
     componentDidMount = () => this.props.onMount(this.pageName)
 
-    reset = () => this.props.onUpdate("pose", { pose: DEFAULT_POSE })
+    reset = () => {
+        const { pose, dimensions } = this.props.params
+        const newPose = {
+            ...pose,
+            leftArm: { ...DEFAULT_POSE.leftArm },
+            rightArm: { ...DEFAULT_POSE.rightArm },
+        }
+        const newDimensions = {
+            ...dimensions,
+            armCoxia: DEFAULT_DIMENSIONS.armCoxia,
+            armFemur: DEFAULT_DIMENSIONS.armFemur,
+            armTibia: DEFAULT_DIMENSIONS.armTibia,
+        }
+        this.props.onUpdate("pose", { pose: newPose })
+        this.props.onUpdate("dimensions", { dimensions: newDimensions })
+    }
 
     toggleMode = () => {
         const WidgetType = this.state.WidgetType === Slider ? NumberInputField : Slider
@@ -35,6 +51,32 @@ class ArmControlPage extends Component {
             newPose.rightArm = { ...pose.rightArm, [angle]: v }
         }
         this.props.onUpdate("pose", { pose: newPose })
+    }
+
+    updateDimension = (name, value) => {
+        const dimensions = {
+            ...this.props.params.dimensions,
+            [name]: Number(value),
+        }
+        this.props.onUpdate("dimensions", { dimensions })
+    }
+
+    get dimensionFields() {
+        const { minVal, maxVal, stepVal } = RANGE_PARAMS.dimensionInputs
+        const dims = this.props.params.dimensions
+        return (
+            <div className="grid-cols-3">
+                {ARM_DIMENSION_NAMES.map(name => (
+                    <NumberInputField
+                        key={name}
+                        name={name}
+                        value={dims[name]}
+                        rangeParams={{ minVal, maxVal, stepVal }}
+                        handleChange={this.updateDimension}
+                    />
+                ))}
+            </div>
+        )
     }
 
     get selectionMenu() {
@@ -97,6 +139,7 @@ class ArmControlPage extends Component {
                 }
             >
                 <div className="grid-cols-1">{this.renderWidget(name)}</div>
+                {this.dimensionFields}
                 <ResetButton reset={this.reset} language={language} />
             </Card>
         )

--- a/src/components/pages/TailControlPage.js
+++ b/src/components/pages/TailControlPage.js
@@ -1,8 +1,9 @@
 import React, { Component } from "react"
 import TailPoseWidget from "../pagePartials/TailPoseWidget"
 import { Card, ResetButton, ToggleSwitch, NumberInputField, Slider } from "../generic"
-import { DEFAULT_TAIL_POSE } from "../../templates"
+import { DEFAULT_TAIL_POSE, DEFAULT_DIMENSIONS } from "../../templates"
 import translations from "../../translations"
+import { TAIL_DIMENSION_NAMES, RANGE_PARAMS } from "../vars"
 
 class TailControlPage extends Component {
     pageName = "tailControl"
@@ -11,9 +12,20 @@ class TailControlPage extends Component {
     componentDidMount = () => this.props.onMount(this.pageName)
 
     reset = () => {
-        const pose = this.props.params.pose
+        const { pose, dimensions } = this.props.params
         const newPose = { ...pose, tail: { ...DEFAULT_TAIL_POSE } }
+        const newDimensions = {
+            ...dimensions,
+            tailSegment1: DEFAULT_DIMENSIONS.tailSegment1,
+            tailSegment2: DEFAULT_DIMENSIONS.tailSegment2,
+            tailSegment3: DEFAULT_DIMENSIONS.tailSegment3,
+            tailSegment4: DEFAULT_DIMENSIONS.tailSegment4,
+            tailSegment5: DEFAULT_DIMENSIONS.tailSegment5,
+            tailThickness: DEFAULT_DIMENSIONS.tailThickness,
+            tailMountAngle: DEFAULT_DIMENSIONS.tailMountAngle,
+        }
         this.props.onUpdate("pose", { pose: newPose })
+        this.props.onUpdate("dimensions", { dimensions: newDimensions })
     }
 
     toggleMode = () => {
@@ -26,6 +38,32 @@ class TailControlPage extends Component {
         const tail = { ...pose.tail, [angle]: value }
         const newPose = { ...pose, tail }
         this.props.onUpdate("pose", { pose: newPose })
+    }
+
+    updateDimension = (name, value) => {
+        const dimensions = {
+            ...this.props.params.dimensions,
+            [name]: Number(value),
+        }
+        this.props.onUpdate("dimensions", { dimensions })
+    }
+
+    get dimensionFields() {
+        const { minVal, maxVal, stepVal } = RANGE_PARAMS.dimensionInputs
+        const dims = this.props.params.dimensions
+        return (
+            <div className="grid-cols-3">
+                {TAIL_DIMENSION_NAMES.map(name => (
+                    <NumberInputField
+                        key={name}
+                        name={name}
+                        value={dims[name]}
+                        rangeParams={{ minVal, maxVal, stepVal }}
+                        handleChange={this.updateDimension}
+                    />
+                ))}
+            </div>
+        )
     }
 
     renderWidget = name => (
@@ -60,6 +98,7 @@ class TailControlPage extends Component {
         return (
             <Card title={<h2>{title}</h2>} other={this.toggleSwitch}>
                 <div className="grid-cols-1">{this.renderWidget("tail")}</div>
+                {this.dimensionFields}
                 <ResetButton reset={this.reset} language={language} />
             </Card>
         )

--- a/src/components/pages/WalkingGaitsPage.js
+++ b/src/components/pages/WalkingGaitsPage.js
@@ -84,8 +84,9 @@ class WalkingGaitsPage extends Component {
     onUpdate = (pose, currentTwist) => {
         this.currentTwist = currentTwist
 
-        const { dimensions } = this.props.params
-        const hexapod = new VirtualHexapod(dimensions, pose, { wontRotate: true })
+        const { dimensions, pose: currentPose } = this.props.params
+        const fullPose = { ...currentPose, ...pose }
+        const hexapod = new VirtualHexapod(dimensions, fullPose, { wontRotate: true })
 
         // ❗❗️HACK When we've passed undefined pose values for some reason
         if (!hexapod || !hexapod.body) {

--- a/src/components/vars.js
+++ b/src/components/vars.js
@@ -16,16 +16,11 @@ const PATH_NAMES = {
 
 const ANGLE_NAMES = ["alpha", "beta", "gamma"]
 const TAIL_ANGLE_NAMES = ["yaw", "theta1", "theta2", "theta3", "theta4", "theta5"]
-const DIMENSION_NAMES = [
-    "front",
-    "side",
-    "middle",
-    "coxia",
-    "femur",
-    "tibia",
-    "armCoxia",
-    "armFemur",
-    "armTibia",
+const DIMENSION_NAMES = ["front", "side", "middle", "coxia", "femur", "tibia"]
+
+const ARM_DIMENSION_NAMES = ["armCoxia", "armFemur", "armTibia"]
+
+const TAIL_DIMENSION_NAMES = [
     "tailSegment1",
     "tailSegment2",
     "tailSegment3",
@@ -178,6 +173,8 @@ export {
     ANGLE_NAMES,
     TAIL_ANGLE_NAMES,
     DIMENSION_NAMES,
+    ARM_DIMENSION_NAMES,
+    TAIL_DIMENSION_NAMES,
     LEG_NAMES,
     ARM_NAMES,
     IK_SLIDERS_LABELS,

--- a/src/templates/hexapodParams.js
+++ b/src/templates/hexapodParams.js
@@ -49,16 +49,16 @@ const DEFAULT_POSE = {
     rightBack: { alpha: 0, beta: 0, gamma: 0 },
     leftArm: { alpha: 0, beta: 80, gamma: 0 },
     rightArm: { alpha: 0, beta: 80, gamma: 0 },
-    tail: { yaw: 0, theta1: 0, theta2: 0, theta3: 0, theta4: 0, theta5: 0 },
+    tail: { yaw: -90, theta1: 20, theta2: 20, theta3: 35, theta4: 55, theta5: 45 },
 }
 
 const DEFAULT_TAIL_POSE = {
-    yaw: 0,
-    theta1: 0,
-    theta2: 0,
-    theta3: 0,
-    theta4: 0,
-    theta5: 0,
+    yaw: -90,
+    theta1: 20,
+    theta2: 20,
+    theta3: 35,
+    theta4: 55,
+    theta5: 45,
 }
 
 const DEFAULT_PATTERN_PARAMS = { alpha: 0, beta: 0, gamma: 0 }


### PR DESCRIPTION
## Summary
- Move arm and tail dimension inputs into their respective control pages
- Set default tail pose to yaw -90, theta1 20, theta2 20, theta3 35, theta4 55, theta5 45
- Use current arm and tail pose for walking gait animation

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6892394295a08324b3e38cf65e23b947