### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,17 +1,25 @@
-name: Deploy React App
+name: build-and-deploy
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
+  pull_request:
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
-      - run: npm install
+          node-version: 16
+      - run: npm ci
+      - run: npm test -- --watchAll=false
       - run: npm run build
-      - run: npm start
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: github.ref == 'refs/heads/main'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build
+

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "hexapod",
     "version": "0.1.0",
     "private": true,
+    "homepage": ".",
     "dependencies": {
         "plotly.js": "^1.54.7",
         "plotly.js-gl3d-dist-min": "^1.54.7",


### PR DESCRIPTION
## Summary
- add GitHub Action to test, build and deploy to GitHub Pages
- support relative paths with homepage field in package.json

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6892b678ba6483249872aaa7ea08c6b3