### PR TITLE
feat: keep camera interaction during animation

### DIFF
--- a/src/components/HexapodPlot.js
+++ b/src/components/HexapodPlot.js
@@ -1,16 +1,10 @@
 import React from "react"
 import createPlotlyComponent from "react-plotly.js/factory"
-import * as defaults from "../templates"
 import getNewPlotParams from "../templates/plotter"
 
 class HexapodPlot extends React.Component {
-    cameraView = defaults.CAMERA_VIEW
     state = { ready: false }
     Plot = null
-
-    logCameraView = relayoutData => {
-        this.cameraView = relayoutData["scene.camera"]
-    }
 
     componentDidMount() {
         import("plotly.js-gl3d-dist-min").then(Plotly => {
@@ -27,12 +21,11 @@ class HexapodPlot extends React.Component {
         if (!this.props.hexapod) {
             return null
         }
-        const [data, layout] = getNewPlotParams(this.props.hexapod, this.cameraView)
+        const [data, layout] = getNewPlotParams(this.props.hexapod)
 
         const props = {
             data,
             layout,
-            onRelayout: this.logCameraView,
             revision: this.props.revision,
             config: { displaylogo: false, responsive: true },
             style: { height: "100%", width: "100%" },

--- a/src/templates/plotter.js
+++ b/src/templates/plotter.js
@@ -1,4 +1,4 @@
-import { DATA, SCENE, LAYOUT, CAMERA_VIEW } from "./"
+import { DATA, SCENE, LAYOUT } from "./"
 
 const _getSumOfDimensions = dimensions =>
     Object.values(dimensions).reduce((sum, dimension) => sum + dimension, 0)
@@ -133,25 +133,23 @@ const _drawHexapod = hexapod => {
     ]
 }
 
-const getNewPlotParams = (hexapod, cameraView) => {
+const getNewPlotParams = hexapod => {
     const data = _drawHexapod(hexapod)
-    if ([null, undefined, {}].includes(cameraView)) {
-        cameraView = CAMERA_VIEW
-    }
     const range = _getSumOfDimensions(hexapod.dimensions)
     const newRange = [-range, range]
     const xaxis = { ...SCENE.xaxis, range: newRange }
     const yaxis = { ...SCENE.yaxis, range: newRange }
     const zaxis = { ...SCENE.zaxis, range: [-10, 2 * range - 10] }
+    const { camera, ...sceneBase } = SCENE
     const scene = {
-        ...SCENE,
+        ...sceneBase,
         xaxis,
         yaxis,
         zaxis,
-        camera: cameraView,
+        uirevision: true,
     }
 
-    const layout = { ...LAYOUT, scene }
+    const layout = { ...LAYOUT, scene, uirevision: true }
 
     return [data, layout]
 }


### PR DESCRIPTION
## Summary
- stop Plotly layout from resetting camera so users can rotate during walking

## Testing
- `npx prettier --config ./.prettierrc.yaml --check src/templates/plotter.js src/components/HexapodPlot.js`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6892c3f8ffe08324836a0e6249ce4a3d